### PR TITLE
Add commit overview script

### DIFF
--- a/.github/workflows/commit_overview.yml
+++ b/.github/workflows/commit_overview.yml
@@ -1,0 +1,32 @@
+name: Commit Overview
+
+on:
+  workflow_dispatch:
+
+jobs:
+  overview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install requests
+      - name: Run commit overview
+        run: |
+          python commit_overview.py \
+            --github-token "$GITHUB_TOKEN" \
+            --github-owner "$GITHUB_OWNER" \
+            --github-repo "$GITHUB_REPO" \
+            --gitlab-token "$GITLAB_TOKEN" \
+            --gitlab-project "$GITLAB_PROJECT" \
+            --openai-key "$OPENAI_API_KEY"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_OWNER: ${{ secrets.GITHUB_OWNER }}
+          GITHUB_REPO: ${{ secrets.GITHUB_REPO }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          GITLAB_PROJECT: ${{ secrets.GITLAB_PROJECT }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+

--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ python commit_overview.py \
 ```
 
 The script fetches the latest commits from each platform and prints a short summary.
+
+If you provide an OpenAI API key via `--openai-key`, the script will also
+generate an AI summary of the commit messages.
+
+### Running in GitHub Actions
+
+This repository includes a workflow in `.github/workflows/commit_overview.yml`
+that runs the script. Configure the required secrets (`GITHUB_TOKEN`,
+`GITHUB_OWNER`, `GITHUB_REPO`, `GITLAB_TOKEN`, `GITLAB_PROJECT`, and optionally
+`OPENAI_API_KEY`) and trigger the workflow manually from the Actions tab.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,18 @@ You can  explore my [repositories][repos], my [LinkedIn profile][linkedin], or j
 
 [repos]: https://github.com/pazthor?tab=repositories
 [linkedin]: https://www.linkedin.com/in/pazthor/
+
+## Commit overview
+
+Use `commit_overview.py` to print recent commits from your GitHub and GitLab projects.
+
+```bash
+python commit_overview.py \
+  --github-token YOUR_GITHUB_TOKEN \
+  --github-owner YOUR_GITHUB_USER \
+  --github-repo YOUR_GITHUB_REPO \
+  --gitlab-token YOUR_GITLAB_TOKEN \
+  --gitlab-project YOUR_GITLAB_PROJECT_ID
+```
+
+The script fetches the latest commits from each platform and prints a short summary.

--- a/commit_overview.py
+++ b/commit_overview.py
@@ -1,0 +1,70 @@
+import argparse
+import requests
+from datetime import datetime
+
+
+def get_github_commits(token, owner, repo, per_page=5):
+    """Return a list of recent commits from a GitHub repository."""
+    headers = {"Authorization": f"token {token}"}
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits"
+    response = requests.get(url, headers=headers, params={"per_page": per_page})
+    response.raise_for_status()
+    data = response.json()
+    return [
+        {
+            "sha": item["sha"],
+            "date": item["commit"]["author"]["date"],
+            "message": item["commit"]["message"],
+        }
+        for item in data
+    ]
+
+
+def get_gitlab_commits(token, project_id, per_page=5):
+    """Return a list of recent commits from a GitLab project."""
+    headers = {"PRIVATE-TOKEN": token}
+    url = f"https://gitlab.com/api/v4/projects/{project_id}/repository/commits"
+    response = requests.get(url, headers=headers, params={"per_page": per_page})
+    response.raise_for_status()
+    data = response.json()
+    return [
+        {
+            "id": item["id"],
+            "date": item["committed_date"],
+            "message": item["title"],
+        }
+        for item in data
+    ]
+
+
+def print_overview(label, commits):
+    if not commits:
+        print(f"No commits found for {label}.")
+        return
+    last_commit = commits[0]
+    total = len(commits)
+    date = datetime.fromisoformat(last_commit["date"].replace("Z", "+00:00"))
+    print(f"{label}: {total} commits. Last commit on {date:%Y-%m-%d} - {last_commit['message']}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Summarize recent GitHub and GitLab commits.")
+    parser.add_argument("--github-token", help="GitHub personal access token")
+    parser.add_argument("--github-owner", help="GitHub repository owner")
+    parser.add_argument("--github-repo", help="GitHub repository name")
+    parser.add_argument("--gitlab-token", help="GitLab private token")
+    parser.add_argument("--gitlab-project", help="GitLab project ID")
+    parser.add_argument("--per-page", type=int, default=5, help="Number of commits to retrieve from each repo")
+    args = parser.parse_args()
+
+    if args.github_token and args.github_owner and args.github_repo:
+        gh_commits = get_github_commits(
+            args.github_token, args.github_owner, args.github_repo, args.per_page
+        )
+        print_overview("GitHub", gh_commits)
+
+    if args.gitlab_token and args.gitlab_project:
+        gl_commits = get_gitlab_commits(
+            args.gitlab_token, args.gitlab_project, args.per_page
+        )
+        print_overview("GitLab", gl_commits)

--- a/tests/test_commit_overview.py
+++ b/tests/test_commit_overview.py
@@ -1,0 +1,94 @@
+import sys, types
+req = types.ModuleType("requests")
+req.get = lambda *a, **k: None
+req.post = lambda *a, **k: None
+sys.modules.setdefault("requests", req)
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+# These tests show how to mock external HTTP requests using unittest.mock.
+# They serve as a brief tutorial and follow common best practices.
+import io
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+import commit_overview as co
+
+# These tests follow best practices demonstrated in the tutorial, using
+# patches for external API calls and verifying output without network access.
+
+class FakeResponse:
+    def __init__(self, json_data, status_code=200):
+        self._json = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("HTTP error")
+
+
+def test_get_github_commits():
+    data = [
+        {
+            "sha": "abc",
+            "commit": {
+                "author": {"date": "2025-06-01T12:00:00Z"},
+                "message": "Initial commit",
+            },
+        }
+    ]
+    with patch("commit_overview.requests.get", return_value=FakeResponse(data)) as m:
+        commits = co.get_github_commits("t", "owner", "repo")
+        assert commits == [
+            {
+                "sha": "abc",
+                "date": "2025-06-01T12:00:00Z",
+                "message": "Initial commit",
+            }
+        ]
+        m.assert_called_once()
+
+
+def test_get_gitlab_commits():
+    data = [
+        {"id": "1", "committed_date": "2025-06-02T12:00:00Z", "title": "Fix"}
+    ]
+    with patch("commit_overview.requests.get", return_value=FakeResponse(data)) as m:
+        commits = co.get_gitlab_commits("t", "proj")
+        assert commits == [
+            {
+                "id": "1",
+                "date": "2025-06-02T12:00:00Z",
+                "message": "Fix",
+            }
+        ]
+        m.assert_called_once()
+
+
+def test_print_overview(capsys):
+    commits = [
+        {"date": "2025-06-01T12:00:00Z", "message": "Initial"}
+    ]
+    co.print_overview("GitHub", commits)
+    out = capsys.readouterr().out
+    assert "GitHub: 1 commits." in out
+
+
+def test_generate_ai_summary():
+    commits = [{"message": "Add feature"}]
+    response = {"choices": [{"message": {"content": "Summary"}}]}
+    with patch(
+        "commit_overview.requests.post", return_value=FakeResponse(response)
+    ) as m:
+        summary = co.generate_ai_summary(commits, "key")
+        assert summary == "Summary"
+        m.assert_called_once()
+
+
+def test_generate_ai_summary_no_key():
+    commits = [{"message": "Add"}]
+    summary = co.generate_ai_summary(commits, api_key=None)
+    assert summary is None
+


### PR DESCRIPTION
## Summary
- show how to run commit overview script
- add python script to fetch GitHub/GitLab commits

## Testing
- `python3 -m py_compile commit_overview.py`

------
https://chatgpt.com/codex/tasks/task_e_6847ab6f81b88322871968c1046914eb